### PR TITLE
Permit to directly pass a Doctrine Query object to the builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ $builder
     ->query('SELECT COUNT(*) total, AVG(prix) prix, console FROM jeux_video WHERE possesseur = :possesseur GROUP BY console')
     ->setParameter(':possesseur',"Kapiamba")
 ```
+
+You can also pass a Doctrine\ORM\Query object instead of a DQL query.
+This allow you to use a repository to store your charts queries.
+
 ## Labels and datasets
 
 After the query configuration,  you can set chart datasets and labels (displayed in the x axis):

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -30,7 +30,12 @@ class Builder extends AbstractBuilder
     }
     
     public function query($query) {
-        $this->q = $query;
+        if($query instanceof Query) {
+            $this->q = $query;
+        } else {
+            $this->q = $this->em->createQuery($query);
+        }
+        
         return $this;
     }
 


### PR DESCRIPTION
With this PR you can directly pass a Doctrine\ORM\Query object to the builder.
So you can use a repository to store all your queries in one place.